### PR TITLE
Add integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .env
+.vagrant

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--order rand

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,22 @@
+sudo: true
+
 language: ruby
-before_install: gem install bundler -v 1.10.6
+
+services:
+  - mysql
+
+before_install:
+  - printf "[mysqld]\nlog-bin=mysql-bin\nserver-id=1\nbinlog-format=ROW\n" | sudo tee /etc/mysql/conf.d/binlog.cnf
+  - sudo service mysql restart
+  - mysql -u root -e 'create database ecco_test;'
+  - gem install bundler -v 1.10.6
+
+env:
+  global:
+    - DATABASE_USER=root
+    - DATABASE_PASS=""
+    - DATABASE_URL=jdbc:mysql://localhost:3306/ecco_test
+
 notifications:
   email: false
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ env:
     - DATABASE_PASS=""
     - DATABASE_URL=jdbc:mysql://localhost:3306/ecco_test
 
+script: rake spec:all
+
 notifications:
   email: false
   hipchat:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - DATABASE_PASS=""
     - DATABASE_URL=jdbc:mysql://localhost:3306/ecco_test
 
-script: rake spec:all
+script: bundle exec rake spec:all
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
   - mysql
 
 before_install:
+  - rvm get head
+  - rvm use jruby-9.0.3.0 --install
   - printf "[mysqld]\nlog-bin=mysql-bin\nserver-id=1\nbinlog-format=ROW\n" | sudo tee /etc/mysql/conf.d/binlog.cnf
   - sudo service mysql restart
   - mysql -u root -e 'create database ecco_test;'

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ env:
     - DATABASE_PASS=""
     - DATABASE_URL=jdbc:mysql://localhost:3306/ecco_test
 
-script: bundle exec rake spec:all
+script: bin/all_specs
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ To install this gem onto your local machine
 
     bundle exec rake install
 
+### Integration tests
+
+The tests needs a MySQL server with replication enabled.
+Ecco includes a Vagrant machine that can be used for this.
+
+Just start it before running the tests
+
+    vagrant up
+
+*Note: Stop any local mysql servers first as it forwards mysql to localhost:3306.*
+
 ## Release
 
 To release a new version, update the version number in `version.rb`, and then run

--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ To install this gem onto your local machine
 
 ### Integration tests
 
+The integration tests don't run by default. To run all the tests, including integration, use
+
+    jruby --dev -G -S rake spec:all
+
 The tests needs a MySQL server with replication enabled.
 Ecco includes a Vagrant machine that can be used for this.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ The integration tests don't run by default. To run all the tests, including inte
     jruby --dev -G -S rake spec:all
 
 The tests needs a MySQL server with replication enabled.
-Ecco includes a Vagrant machine that can be used for this.
+
+Ecco includes a Vagrant machine, that can be used for this. Note that your Vagrant host need to have [Ansible] installed as it is used for provisioning.
 
 Just start it before running the tests
 
@@ -107,3 +108,4 @@ which will create a git tag for the version, push git commits and tags, and push
 The gem is available as open source under the terms of the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
 
 [mysql-binlog-connector-java]: https://github.com/shyiko/mysql-binlog-connector-java
+[Ansible]: http://www.ansible.com/

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Note: You need Maven to download
 
 Run the tests
 
-    jruby --dev -G -S rake
+    bin/specs
 
 For an interactive prompt
 
@@ -83,7 +83,7 @@ To install this gem onto your local machine
 
 The integration tests don't run by default. To run all the tests, including integration, use
 
-    jruby --dev -G -S rake spec:all
+    bin/all_specs
 
 The tests needs a MySQL server with replication enabled.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,13 @@
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
-RSpec::Core::RakeTask.new(:spec)
+RSpec::Core::RakeTask.new(:spec) do |task|
+  task.exclude_pattern = "spec/integration/*_spec.rb"
+end
+
+namespace :spec do
+  RSpec::Core::RakeTask.new(:all)
+end
 
 task :default => :spec
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,8 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.provision :ansible do |ansible|
+    ansible.playbook = "vagrant/playbook.yml"
+  end
+
+  config.vm.network :forwarded_port, host: 3306, guest: 3306
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,11 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
-  config.vm.provision :ansible do |ansible|
-    ansible.playbook = "vagrant/playbook.yml"
-  end
+  config.vm.define "ecco-test" do |ubuntu|
+    ubuntu.vm.hostname = "ecco-test"
+    ubuntu.vm.box = "ubuntu/trusty64"
+    ubuntu.vm.provision :ansible do |ansible|
+      ansible.playbook = "vagrant/playbook.yml"
+    end
 
-  config.vm.network :forwarded_port, host: 3306, guest: 3306
+    ubuntu.vm.network :forwarded_port, host: 3306, guest: 3306
+  end
 end

--- a/bin/all_specs
+++ b/bin/all_specs
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+jruby --dev -G -S rake spec:all

--- a/bin/specs
+++ b/bin/specs
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+jruby --dev -G -S rake

--- a/ecco.gemspec
+++ b/ecco.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "sequel"
+  spec.add_development_dependency "jdbc-mysql"
 end

--- a/lib/ecco/client.rb
+++ b/lib/ecco/client.rb
@@ -1,6 +1,7 @@
 require "ext/mysql-binlog-connector-java-#{Ecco::MYSQL_BINLOG_CONNECTOR_VERSION}.jar"
 require "ecco/row_event_listener"
 require "ecco/save_event_listener"
+require "ecco/error"
 
 module Ecco
   class Client
@@ -31,6 +32,8 @@ module Ecco
 
     def start
       @client.connect
+    rescue java.io.IOException => e
+      raise Ecco::Error::ConnectionError, e.get_message
     end
 
     def stop

--- a/lib/ecco/client.rb
+++ b/lib/ecco/client.rb
@@ -13,6 +13,7 @@ module Ecco
     def_delegators :@client, :set_binlog_position, :get_binlog_position
 
     java_import com.github.shyiko.mysql.binlog.BinaryLogClient
+    java_import java.io.IOException
 
     def initialize(hostname: "localhost", port: 3306, username:, password:)
       @client = BinaryLogClient.new(hostname, port, username, password)
@@ -34,7 +35,7 @@ module Ecco
 
     def start
       @client.connect
-    rescue java.io.IOException => e
+    rescue IOException => e
       raise Ecco::Error::ConnectionError, e.get_message
     end
 

--- a/lib/ecco/client.rb
+++ b/lib/ecco/client.rb
@@ -32,5 +32,9 @@ module Ecco
     def start
       @client.connect
     end
+
+    def stop
+      @client.disconnect
+    end
   end
 end

--- a/lib/ecco/client.rb
+++ b/lib/ecco/client.rb
@@ -5,6 +5,8 @@ require "ecco/error"
 
 module Ecco
   class Client
+    DEFAULT_CONNECT_TIMEOUT = 3000 # ms
+
     extend Forwardable
     def_delegators :@client, :set_server_id, :get_server_id
     def_delegators :@client, :set_binlog_filename, :get_binlog_filename
@@ -34,6 +36,10 @@ module Ecco
       @client.connect
     rescue java.io.IOException => e
       raise Ecco::Error::ConnectionError, e.get_message
+    end
+
+    def start_in_thread(connect_timeout: DEFAULT_CONNECT_TIMEOUT)
+      @client.connect(connect_timeout)
     end
 
     def stop

--- a/lib/ecco/error.rb
+++ b/lib/ecco/error.rb
@@ -1,0 +1,6 @@
+module Ecco
+  module Error
+    class ConnectionError < StandardError
+    end
+  end
+end

--- a/spec/database_helper.rb
+++ b/spec/database_helper.rb
@@ -1,0 +1,36 @@
+require "sequel"
+
+class DatabaseHelper
+  USER = ENV.fetch("DATABASE_USER")
+  PASS = ENV.fetch("DATABASE_PASS")
+  DB   = Sequel.connect(ENV.fetch("DATABASE_URL"),
+    user:     USER,
+    password: PASS,
+  )
+
+  def self.create_table(name, columns: 1)
+    DB.create_table!(name) do
+      primary_key :id
+
+      1.upto(columns) do |i|
+        String :"column#{i}"
+      end
+    end
+  end
+
+  def self.drop_table(name)
+    DB.drop_table(name)
+  end
+
+  def self.insert(table_name, values_hash)
+    DB[table_name].insert(values_hash)
+  end
+
+  def self.update(table_name, id:, columns:)
+    DB[table_name].where(id: id).update(columns)
+  end
+
+  def self.delete(table_name, id:)
+    DB[table_name].where(id: id).delete
+  end
+end

--- a/spec/database_helper.rb
+++ b/spec/database_helper.rb
@@ -37,4 +37,8 @@ class DatabaseHelper
   def self.delete(table_name, id:)
     DB[table_name].where(id: id).delete
   end
+
+  def self.flush_logs
+    DB.run("FLUSH BINARY LOGS")
+  end
 end

--- a/spec/database_helper.rb
+++ b/spec/database_helper.rb
@@ -1,5 +1,9 @@
 require "sequel"
 
+ENV["DATABASE_USER"] ||= "root"
+ENV["DATABASE_PASS"] ||= ""
+ENV["DATABASE_URL"]  ||= "jdbc:mysql://localhost:3306/ecco_test"
+
 class DatabaseHelper
   USER = ENV.fetch("DATABASE_USER")
   PASS = ENV.fetch("DATABASE_PASS")

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -29,6 +29,35 @@ describe Ecco::Client do
     DatabaseHelper.drop_table(table_name)
   end
 
+  describe "#start_in_thread" do
+    context "when called multiple times" do
+      it "should throw an error" do
+        subject.start_in_thread
+
+        expect { subject.start_in_thread }.to raise_error(java.util.concurrent.TimeoutException)
+
+        subject.stop
+      end
+    end
+  end
+
+  describe "#stop" do
+    context "when called multiple times" do
+      it "should not throw an error" do
+        subject.start_in_thread
+
+        subject.stop
+        expect { subject.stop }.not_to raise_error
+      end
+    end
+
+    context "when called before started" do
+      it "should not throw an error" do
+        expect { subject.stop }.not_to raise_error
+      end
+    end
+  end
+
   describe "#set_binlog_filename, #set_binlog_position" do
     context "when position and filename is set" do
       let(:old_position) do

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -1,5 +1,8 @@
 require "spec_helper"
 
+import java.util.logging.Logger
+import java.util.logging.Level
+
 describe Ecco::Client do
   subject do
     described_class.new(
@@ -11,6 +14,12 @@ describe Ecco::Client do
   let(:table_name)   { :ecco_test_table }
   let(:column_value) { "a value" }
   let(:mysql_row)    { { column1: column_value } }
+
+  before(:all) do
+    root_logger = Logger.get_logger("");
+    # The first handler is by default the console
+    root_logger.get_handlers.first.set_level(Level::WARNING)
+  end
 
   before do
     DatabaseHelper.create_table(table_name, columns: 1)

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -16,7 +16,7 @@ describe Ecco::Client do
   let(:mysql_row)    { { column1: column_value } }
 
   before(:all) do
-    root_logger = Logger.get_logger("");
+    root_logger = Logger.get_logger("")
     # The first handler is by default the console
     root_logger.get_handlers.first.set_level(Level::WARNING)
   end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -206,7 +206,7 @@ describe Ecco::Client do
       end
 
       it "will raise an error" do
-        expect { subject.start }.to raise_error(java.io.IOException)
+        expect { subject.start }.to raise_error(Ecco::Error::ConnectionError)
       end
     end
 
@@ -219,7 +219,7 @@ describe Ecco::Client do
       end
 
       it "will raise an error" do
-        expect { subject.start }.to raise_error(java.io.IOException)
+        expect { subject.start }.to raise_error(Ecco::Error::ConnectionError)
       end
     end
   end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "timeout"
 
 describe Ecco::Client do
   subject do

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -37,7 +37,7 @@ describe Ecco::Client do
           password: DatabaseHelper::PASS,
         )
 
-        TestHelper.get_save_position_events_from_client(another_client) do
+        TestHelper.wait_for_save_position_events(another_client) do
           DatabaseHelper.insert(table_name, mysql_row)
         end
       end
@@ -51,7 +51,7 @@ describe Ecco::Client do
       end
 
       it "should start at that position" do
-        subject_position = TestHelper.get_save_position_events_from_client(subject)
+        subject_position = TestHelper.wait_for_save_position_events(subject)
 
         expect(subject_position).to eq(old_position)
       end
@@ -61,7 +61,7 @@ describe Ecco::Client do
   describe "#on_row_event" do
     context "when a row is inserted" do
       let(:row_event) do
-        TestHelper.get_row_events_from_client(subject) do
+        TestHelper.wait_for_row_events(subject) do
           DatabaseHelper.insert(table_name, mysql_row)
         end
       end
@@ -83,7 +83,7 @@ describe Ecco::Client do
       let(:row_event) do
         id = DatabaseHelper.insert(table_name, mysql_row)
 
-        TestHelper.get_row_events_from_client(subject) do
+        TestHelper.wait_for_row_events(subject) do
           DatabaseHelper.update(table_name, id: id, columns: update_columns )
         end
       end
@@ -105,7 +105,7 @@ describe Ecco::Client do
       let(:row_event) do
         id = DatabaseHelper.insert(table_name, mysql_row)
 
-        TestHelper.get_row_events_from_client(subject) do
+        TestHelper.wait_for_row_events(subject) do
           DatabaseHelper.delete(table_name, id: id)
         end
       end
@@ -128,7 +128,7 @@ describe Ecco::Client do
 
       let(:another_table) { :another_table_name }
       let(:row_events) do
-        TestHelper.get_row_events_from_client(subject, count: 2) do
+        TestHelper.wait_for_row_events(subject, count: 2) do
           DatabaseHelper.insert(table_name, mysql_row)
           DatabaseHelper.insert(another_table, mysql_row)
         end
@@ -143,7 +143,7 @@ describe Ecco::Client do
     context "when the log files are rotated" do
       let(:event_count) { 10 }
       let(:row_events) do
-        TestHelper.get_row_events_from_client(subject, count: event_count) do
+        TestHelper.wait_for_row_events(subject, count: event_count) do
           1.upto(event_count) do |i|
             DatabaseHelper.insert(table_name, mysql_row)
             DatabaseHelper.flush_logs if i == 1
@@ -161,7 +161,7 @@ describe Ecco::Client do
     context "when there are multiple events after each other" do
       let(:event_count) { 10 }
       let(:save_events) do
-        TestHelper.get_save_position_events_from_client(subject, count: event_count) do
+        TestHelper.wait_for_save_position_events(subject, count: event_count) do
           1.upto(event_count) do |i|
             DatabaseHelper.insert(table_name, mysql_row)
           end
@@ -178,7 +178,7 @@ describe Ecco::Client do
     context "when the log files are rotated" do
       let(:event_count) { 10 }
       let(:save_events) do
-        TestHelper.get_save_position_events_from_client(subject, count: event_count) do
+        TestHelper.wait_for_save_position_events(subject, count: event_count) do
           1.upto(event_count) do |i|
             DatabaseHelper.insert(table_name, mysql_row)
             DatabaseHelper.flush_logs if i == 1

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -29,35 +29,6 @@ describe Ecco::Client do
     DatabaseHelper.drop_table(table_name)
   end
 
-  describe "#start_in_thread" do
-    context "when called multiple times" do
-      it "should throw an error" do
-        subject.start_in_thread
-
-        expect { subject.start_in_thread }.to raise_error(java.util.concurrent.TimeoutException)
-
-        subject.stop
-      end
-    end
-  end
-
-  describe "#stop" do
-    context "when called multiple times" do
-      it "should not throw an error" do
-        subject.start_in_thread
-
-        subject.stop
-        expect { subject.stop }.not_to raise_error
-      end
-    end
-
-    context "when called before started" do
-      it "should not throw an error" do
-        expect { subject.stop }.not_to raise_error
-      end
-    end
-  end
-
   describe "#set_binlog_filename, #set_binlog_position" do
     context "when position and filename is set" do
       let(:old_position) do

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -194,4 +194,34 @@ describe Ecco::Client do
       end
     end
   end
+
+  describe "#start" do
+    context "when given a non-existent server" do
+      subject do
+        described_class.new(
+          hostname: "somewhere_over_the_rainbow",
+          username: DatabaseHelper::USER,
+          password: DatabaseHelper::PASS,
+        )
+      end
+
+      it "will raise an error" do
+        expect { subject.start }.to raise_error(java.io.IOException)
+      end
+    end
+
+    context "when given bad credentials" do
+      subject do
+        described_class.new(
+          username: DatabaseHelper::USER,
+          password: "this_is_not_the_password",
+        )
+      end
+
+      it "will raise an error" do
+        expect { subject.start }.to raise_error(java.io.IOException)
+      end
+    end
+  end
+
 end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
-import java.util.logging.Logger
-import java.util.logging.Level
+java_import java.util.logging.Logger
+java_import java.util.logging.Level
 
 describe Ecco::Client do
   subject do

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -1,0 +1,58 @@
+require "spec_helper"
+require "timeout"
+
+describe Ecco::Client do
+  subject do
+    described_class.new(
+      username: DatabaseHelper::USER,
+      password: DatabaseHelper::PASS,
+    )
+  end
+
+  let(:table_name)   { :ecco_test_table }
+  let(:mysql_row)    { { column1: "a value" } }
+
+  before do
+    DatabaseHelper.create_table(table_name, columns: 1)
+  end
+
+  after do
+    DatabaseHelper.drop_table(table_name)
+  end
+
+  context "when a row is inserted" do
+    it "should receive a row event with correct type" do
+      row_event = TestHelper.get_first_row_event_from_client(subject) do
+        DatabaseHelper.insert(table_name, mysql_row)
+      end
+
+      expect(row_event.type).to eq("WRITE_ROWS")
+    end
+  end
+
+  context "when a row is updated" do
+    let(:columns) { { column1: "another value" } }
+
+    it "should receive a row event with correct type" do
+      id = DatabaseHelper.insert(table_name, mysql_row)
+
+      row_event = TestHelper.get_first_row_event_from_client(subject) do
+        DatabaseHelper.update(table_name, id: id, columns: columns )
+      end
+
+      expect(row_event.type).to eq("UPDATE_ROWS")
+    end
+  end
+
+  context "when a row is deleted" do
+    it "should receive a row event with correct type" do
+      id = DatabaseHelper.insert(table_name, mysql_row)
+
+      row_event = TestHelper.get_first_row_event_from_client(subject) do
+        DatabaseHelper.delete(table_name, id: id)
+      end
+
+      expect(row_event.type).to eq("DELETE_ROWS")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,3 +4,6 @@ require "ecco"
 
 require_relative "client_context"
 require_relative "event_context"
+
+require_relative "test_helper"
+require_relative "database_helper"

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -50,6 +50,6 @@ class TestHelper
       yield
     end
   rescue Timeout::Error => exception
-    raise exception, "No binlog events received"
+    raise exception, "No binlog events received within #{CLIENT_TIMEOUT} seconds"
   end
 end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,21 +1,56 @@
 class TestHelper
-  def self.get_first_row_event_from_client(ecco_client)
-    received_row_event = nil
+  def self.get_row_events_from_client(ecco_client, count: 1)
+    received_row_events = []
 
     ecco_client.on_row_event do |row_event|
-      received_row_event = row_event
-      ecco_client.stop
+      received_row_events << row_event
+      ecco_client.stop if received_row_events.count == count
     end
 
+    thread = start_client_in_thread(ecco_client)
+
+    yield
+
+    thread.join
+
+    # So you don't have to run .first in the tests
+    return received_row_events.first if count == 1
+
+    received_row_events
+  end
+
+  def self.get_save_position_events_from_client(ecco_client, count: 1)
+    received_save_position_events = []
+
+    ecco_client.on_save_position do |filename, position|
+      received_save_position_events << {
+        filename: filename,
+        position: position,
+      }
+      ecco_client.stop if received_save_position_events.count == count
+    end
+
+    thread = start_client_in_thread(ecco_client)
+
+    yield
+
+    thread.join
+
+    # So you don't have to run .first in the tests
+    return received_save_position_events.first if count == 1
+
+    received_save_position_events
+  end
+
+  def self.start_client_in_thread(ecco_client)
     thread = Thread.new do |t|
       ecco_client.start
     end
 
     sleep 1
-    yield
 
-    thread.join
-
-    received_row_event
+    thread
   end
+
+  private_class_method :start_client_in_thread
 end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,5 +1,5 @@
 class TestHelper
-  def self.get_row_events_from_client(ecco_client, count: 1)
+  def self.get_row_events_from_client(ecco_client, count: 1, &block)
     received_row_events = []
 
     ecco_client.on_row_event do |row_event|
@@ -7,19 +7,12 @@ class TestHelper
       ecco_client.stop if received_row_events.count == count
     end
 
-    thread = start_client_in_thread(ecco_client)
+    start_client_in_thread_and_run_block(ecco_client, &block)
 
-    yield
-
-    thread.join
-
-    # So you don't have to run .first in the tests
-    return received_row_events.first if count == 1
-
-    received_row_events
+    count == 1 ? received_row_events.first : received_row_events
   end
 
-  def self.get_save_position_events_from_client(ecco_client, count: 1)
+  def self.get_save_position_events_from_client(ecco_client, count: 1, &block)
     received_save_position_events = []
 
     ecco_client.on_save_position do |filename, position|
@@ -30,27 +23,22 @@ class TestHelper
       ecco_client.stop if received_save_position_events.count == count
     end
 
-    thread = start_client_in_thread(ecco_client)
+    start_client_in_thread_and_run_block(ecco_client, &block)
 
-    yield if block_given?
-
-    thread.join
-
-    # So you don't have to run .first in the tests
-    return received_save_position_events.first if count == 1
-
-    received_save_position_events
+    count == 1 ? received_save_position_events.first : received_save_position_events
   end
 
-  def self.start_client_in_thread(ecco_client)
+  def self.start_client_in_thread_and_run_block(ecco_client)
     thread = Thread.new do |t|
       ecco_client.start
     end
 
     sleep 1
 
-    thread
+    yield if block_given?
+
+    thread.join
   end
 
-  private_class_method :start_client_in_thread
+  private_class_method :start_client_in_thread_and_run_block
 end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -1,0 +1,21 @@
+class TestHelper
+  def self.get_first_row_event_from_client(ecco_client)
+    received_row_event = nil
+
+    ecco_client.on_row_event do |row_event|
+      received_row_event = row_event
+      ecco_client.stop
+    end
+
+    thread = Thread.new do |t|
+      ecco_client.start
+    end
+
+    sleep 1
+    yield
+
+    thread.join
+
+    received_row_event
+  end
+end

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -17,7 +17,7 @@ class TestHelper
 
       sleep SLEEP_TIME while received_events.count < count
 
-      count == 1 ? received_events.first : received_events
+      received_events
     end
   ensure
     ecco_client.stop
@@ -39,7 +39,7 @@ class TestHelper
 
       sleep SLEEP_TIME while received_events.count < count
 
-      count == 1 ? received_events.first : received_events
+      received_events
     end
   ensure
     ecco_client.stop

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -32,7 +32,7 @@ class TestHelper
 
     thread = start_client_in_thread(ecco_client)
 
-    yield
+    yield if block_given?
 
     thread.join
 

--- a/vagrant/files/ecco-my.cnf
+++ b/vagrant/files/ecco-my.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+log-bin=mysql-bin
+server-id=1
+binlog-format=ROW
+bind-address=0.0.0.0

--- a/vagrant/playbook.yml
+++ b/vagrant/playbook.yml
@@ -1,0 +1,27 @@
+---
+- hosts: all
+  sudo: yes
+  tasks:
+
+  - name: Update package cache
+    apt: update_cache=yes
+
+  - name: Install ansible dependencies
+    apt: name={{ item }}
+    with_items:
+      - python-mysqldb
+
+  - name: Install mysql server
+    apt: name=mysql-server state=present
+
+  - name: Copy mysql config file
+    copy: src=files/ecco-my.cnf dest=/etc/mysql/conf.d/
+
+  - name: Allow mysql root connection from remote hosts
+    mysql_user: name=root password="" host=% priv=*.*:ALL state=present
+
+  - name: Restart mysql
+    service: name=mysql state=restarted
+
+  - name: Create database
+    mysql_db: name=ecco_test


### PR DESCRIPTION
Tested it with freebsd-mysql vagrant machine from ansible.

Requires the environment variables `DATABASE_URL`, `DATABASE_USER` and `DATABASE_PASS` because the JDBC adapter for sequel didn't like `username:password` inside the url for some reason :confused:.
- Add #stop method to Ecco::Client to be able to stop it when testing.
- Two helper classes:
  - DatabaseHelper - Inserts/updates/deletes table rows
  - TestHelper - Starts/stops ecco and returns the received row event
- Integration tests which checks that #on_row_event receives the correct type.
### Todo
- [x] MySQL with replication enabled on Travis
- [x] Vagrantfile
- [x] Documentation
- [x] Do not run integration tests by default
- [x] More tests
  - [x] Ensure that database/table information is correct
  - [x] Ensure that we can handle file rotations
  - [x] Set and get public properties
- [x] Remove duplicated code if possible
- [x] ~~Test for `client.stop`, `client.start` and `client.start_in_thread` (they are already tested implicitly in most of the tests)~~

close #2 
