### PR TITLE
MySQL 5.6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /tmp/
 .env
 .vagrant
+*.retry

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - DATABASE_USER=root
     - DATABASE_PASS=""
     - DATABASE_URL=jdbc:mysql://localhost:3306/ecco_test
+    - JRUBY_OPTS='--client -J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -Xcext.enabled=false -J-Xss2m -Xcompile.invokedynamic=false'
 
 script: bin/all_specs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ addons:
     - mysql-server-5.6
     - mysql-client-core-5.6
     - mysql-client-5.6
+    - haveged # Extra entropy
 
 language: ruby
 
@@ -17,10 +18,11 @@ services:
   - mysql
 
 before_install:
+  - sudo service haveged start # Extra entropy too ensure quick start time for JRuby
   - printf "[mysqld]\nlog-bin=mysql-bin\nserver-id=1\nbinlog-format=ROW\n" | sudo tee /etc/mysql/conf.d/binlog.cnf
   - sudo service mysql restart
   - mysql -u root -e 'create database ecco_test;'
-  - gem install --verbose bundler
+  - gem install bundler
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - printf "[mysqld]\nlog-bin=mysql-bin\nserver-id=1\nbinlog-format=ROW\n" | sudo tee /etc/mysql/conf.d/binlog.cnf
   - sudo service mysql restart
   - mysql -u root -e 'create database ecco_test;'
-  - gem install bundler
+  - gem install --verbose bundler
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - printf "[mysqld]\nlog-bin=mysql-bin\nserver-id=1\nbinlog-format=ROW\n" | sudo tee /etc/mysql/conf.d/binlog.cnf
   - sudo service mysql restart
   - mysql -u root -e 'create database ecco_test;'
-  - gem install bundler -v 1.10.6
+  - gem install bundler
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 sudo: true
 
+dist: trusty
+addons:
+  apt:
+    packages:
+    - mysql-server-5.6
+    - mysql-client-core-5.6
+    - mysql-client-5.6
+
 language: ruby
 
 rvm:
-- jruby-9.0.5.0
+  - jruby-9.0.5.0
 
 services:
   - mysql

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/twingly/ecco.svg?branch=master)](https://travis-ci.org/twingly/ecco)
 
-MySQL replication binlog parser using [mysql-binlog-connector-java].
+MySQL (version 5.5 and 5.6) replication binlog parser using [mysql-binlog-connector-java].
 
 ## Installation
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,5 +7,8 @@ Vagrant.configure("2") do |config|
     end
 
     ubuntu.vm.network :forwarded_port, host: 3306, guest: 3306
+    ubuntu.vm.provider "virtualbox" do |vbox|
+      vbox.memory = 1024
+    end
   end
 end

--- a/lib/ecco/row_event_listener.rb
+++ b/lib/ecco/row_event_listener.rb
@@ -3,14 +3,19 @@ require "ecco/row_event"
 
 module Ecco
   class RowEventListener < EventListener
-    ROW_EVENTS = [
+    WRITE_EVENTS = [
       EventType::WRITE_ROWS,
       EventType::EXT_WRITE_ROWS,
+    ]
+    UPDATE_EVENTS = [
       EventType::UPDATE_ROWS,
       EventType::EXT_UPDATE_ROWS,
+    ]
+    DELETE_EVENTS = [
       EventType::DELETE_ROWS,
       EventType::EXT_DELETE_ROWS,
     ]
+    ROW_EVENTS = WRITE_EVENTS + UPDATE_EVENTS + DELETE_EVENTS
 
     def table_event
       EventType::TABLE_MAP
@@ -29,9 +34,17 @@ module Ecco
         @table_map_event = event
       when *accepted_events
         row_event          = Ecco::RowEvent.new
-        row_event.type     = type.to_s
         row_event.table_id = data.get_table_id
         row_event.rows     = data.rows
+
+        row_event.type =
+          if WRITE_EVENTS.include?(type)
+            "WRITE_ROWS"
+          elsif UPDATE_EVENTS.include?(type)
+            "UPDATE_ROWS"
+          elsif DELETE_EVENTS.include?(type)
+            "DELETE_ROWS"
+          end
 
         if @table_map_event
           table_event_data = @table_map_event.get_data

--- a/lib/ecco/row_event_listener.rb
+++ b/lib/ecco/row_event_listener.rb
@@ -5,8 +5,11 @@ module Ecco
   class RowEventListener < EventListener
     ROW_EVENTS = [
       EventType::WRITE_ROWS,
+      EventType::EXT_WRITE_ROWS,
       EventType::UPDATE_ROWS,
+      EventType::EXT_UPDATE_ROWS,
       EventType::DELETE_ROWS,
+      EventType::EXT_DELETE_ROWS,
     ]
 
     def table_event

--- a/lib/ecco/row_event_listener.rb
+++ b/lib/ecco/row_event_listener.rb
@@ -3,19 +3,12 @@ require "ecco/row_event"
 
 module Ecco
   class RowEventListener < EventListener
-    WRITE_EVENTS = [
-      EventType::WRITE_ROWS,
-      EventType::EXT_WRITE_ROWS,
-    ]
-    UPDATE_EVENTS = [
-      EventType::UPDATE_ROWS,
-      EventType::EXT_UPDATE_ROWS,
-    ]
-    DELETE_EVENTS = [
-      EventType::DELETE_ROWS,
-      EventType::EXT_DELETE_ROWS,
-    ]
-    ROW_EVENTS = WRITE_EVENTS + UPDATE_EVENTS + DELETE_EVENTS
+    # MySQL v1 and v2 row events
+    WRITE_EVENTS  = [EventType::WRITE_ROWS,  EventType::EXT_WRITE_ROWS]
+    UPDATE_EVENTS = [EventType::UPDATE_ROWS, EventType::EXT_UPDATE_ROWS]
+    DELETE_EVENTS = [EventType::DELETE_ROWS, EventType::EXT_DELETE_ROWS]
+
+    ROW_EVENTS  = WRITE_EVENTS + UPDATE_EVENTS + DELETE_EVENTS
 
     def table_event
       EventType::TABLE_MAP
@@ -36,15 +29,7 @@ module Ecco
         row_event          = Ecco::RowEvent.new
         row_event.table_id = data.get_table_id
         row_event.rows     = data.rows
-
-        row_event.type =
-          if WRITE_EVENTS.include?(type)
-            "WRITE_ROWS"
-          elsif UPDATE_EVENTS.include?(type)
-            "UPDATE_ROWS"
-          elsif DELETE_EVENTS.include?(type)
-            "DELETE_ROWS"
-          end
+        row_event.type     = row_type_to_string(type)
 
         if @table_map_event
           table_event_data = @table_map_event.get_data
@@ -54,6 +39,18 @@ module Ecco
         end
 
         @callback.call(row_event)
+      end
+    end
+
+    private
+
+    def row_type_to_string(type)
+      if WRITE_EVENTS.include?(type)
+        "WRITE_ROWS"
+      elsif UPDATE_EVENTS.include?(type)
+        "UPDATE_ROWS"
+      elsif DELETE_EVENTS.include?(type)
+        "DELETE_ROWS"
       end
     end
   end

--- a/lib/ecco/save_event_listener.rb
+++ b/lib/ecco/save_event_listener.rb
@@ -6,8 +6,11 @@ module Ecco
       EventType::QUERY,
       EventType::ROTATE,
       EventType::WRITE_ROWS,
+      EventType::EXT_WRITE_ROWS,
       EventType::UPDATE_ROWS,
+      EventType::EXT_UPDATE_ROWS,
       EventType::DELETE_ROWS,
+      EventType::EXT_DELETE_ROWS,
     ]
 
     def accepted_events

--- a/spec/event_context.rb
+++ b/spec/event_context.rb
@@ -1,10 +1,12 @@
+java_import com.github.shyiko.mysql.binlog.event.EventType
+
 shared_context "event" do
   let(:table_id) { 1 }
   let(:rows) { double("List") }
   let(:database) { "some_database" }
   let(:table) { "some_table" }
-  let(:table_event_type) { "event_type_table_map" }
-  let(:row_event_type) { "event_type_write_rows" }
+  let(:table_event_type) { EventType::TABLE_MAP }
+  let(:row_event_type) { EventType::EXT_WRITE_ROWS }
 
   let(:table_event) do
     event = double("Event")

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -93,7 +93,7 @@ describe Ecco::Client do
       let(:row_event) { row_events.first }
 
       it "should receive a row event with correct type" do
-        expect(row_event.type).to eq("EXT_WRITE_ROWS")
+        expect(row_event.type).to eq("WRITE_ROWS")
       end
 
       it "should receive a row event with the inserted row" do
@@ -117,7 +117,7 @@ describe Ecco::Client do
       let(:row_event) { row_events.first }
 
       it "should receive a row event with correct type" do
-        expect(row_event.type).to eq("EXT_UPDATE_ROWS")
+        expect(row_event.type).to eq("UPDATE_ROWS")
       end
 
       it "should receive a row event with the old and updated row" do
@@ -141,7 +141,7 @@ describe Ecco::Client do
       let(:row_event) { row_events.first }
 
       it "should receive a row event with correct type" do
-        expect(row_event.type).to eq("EXT_DELETE_ROWS")
+        expect(row_event.type).to eq("DELETE_ROWS")
       end
 
       it "should receive a row event with the deleted row" do

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -68,7 +68,9 @@ describe Ecco::Client do
 
         DatabaseHelper.insert(table_name, mysql_row)
 
-        sleep 0.1 while event_order.count < events_to_wait_for
+        TestHelper.with_timeout do
+          sleep 0.1 while event_order.count < events_to_wait_for
+        end
         subject.stop
         event_order.last(2)
       end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -93,7 +93,7 @@ describe Ecco::Client do
       let(:row_event) { row_events.first }
 
       it "should receive a row event with correct type" do
-        expect(row_event.type).to eq("WRITE_ROWS")
+        expect(row_event.type).to eq("EXT_WRITE_ROWS")
       end
 
       it "should receive a row event with the inserted row" do
@@ -117,7 +117,7 @@ describe Ecco::Client do
       let(:row_event) { row_events.first }
 
       it "should receive a row event with correct type" do
-        expect(row_event.type).to eq("UPDATE_ROWS")
+        expect(row_event.type).to eq("EXT_UPDATE_ROWS")
       end
 
       it "should receive a row event with the old and updated row" do
@@ -141,7 +141,7 @@ describe Ecco::Client do
       let(:row_event) { row_events.first }
 
       it "should receive a row event with correct type" do
-        expect(row_event.type).to eq("DELETE_ROWS")
+        expect(row_event.type).to eq("EXT_DELETE_ROWS")
       end
 
       it "should receive a row event with the deleted row" do

--- a/spec/lib/ecco/row_event_listener_spec.rb
+++ b/spec/lib/ecco/row_event_listener_spec.rb
@@ -26,7 +26,7 @@ describe Ecco::RowEventListener do
       subject.on_event(table_event)
       subject.on_event(row_event)
 
-      expect(actual_type).to eq(row_event_type)
+      expect(actual_type).to eq("WRITE_ROWS")
       expect(actual_table_id).to eq(table_id)
       expect(actual_rows).to eq(rows)
       expect(actual_database).to eq(database)

--- a/spec/lib/ecco/row_event_listener_spec.rb
+++ b/spec/lib/ecco/row_event_listener_spec.rb
@@ -5,10 +5,12 @@ describe Ecco::RowEventListener do
 
     subject { described_class.new(client) }
 
-    it "should return a row event with correct values" do
+    before do
       allow(subject).to receive(:accepted_events) { [row_event_type] }
       allow(subject).to receive(:table_event) { table_event_type }
+    end
 
+    it "should return a row event with correct values" do
       actual_type     = nil
       actual_table_id = 0
       actual_rows     = nil
@@ -26,11 +28,101 @@ describe Ecco::RowEventListener do
       subject.on_event(table_event)
       subject.on_event(row_event)
 
-      expect(actual_type).to eq("WRITE_ROWS")
+      expect(actual_type).not_to be_empty
       expect(actual_table_id).to eq(table_id)
       expect(actual_rows).to eq(rows)
       expect(actual_database).to eq(database)
       expect(actual_table).to eq(table)
+    end
+
+    describe "RowEvent#type" do
+      context "MySQL 5.5 v1 ROW_EVENTS" do
+        context "WRITE_ROWS" do
+          let(:row_event_type) { EventType::WRITE_ROWS }
+          it "should return WRITE_ROWS" do
+            actual_type = nil
+            subject.callback = Proc.new do |row_event|
+              actual_type = row_event.type
+            end
+
+            subject.on_event(row_event)
+
+            expect(actual_type).to eq("WRITE_ROWS")
+          end
+        end
+
+        context "UPDATE_ROWS" do
+          let(:row_event_type) { EventType::UPDATE_ROWS }
+          it "should return UPDATE_ROWS" do
+            actual_type = nil
+            subject.callback = Proc.new do |row_event|
+              actual_type = row_event.type
+            end
+
+            subject.on_event(row_event)
+
+            expect(actual_type).to eq("UPDATE_ROWS")
+          end
+        end
+
+        context "DELETE_ROWS" do
+          let(:row_event_type) { EventType::DELETE_ROWS }
+          it "should return DELETE_ROWS" do
+            actual_type = nil
+            subject.callback = Proc.new do |row_event|
+              actual_type = row_event.type
+            end
+
+            subject.on_event(row_event)
+
+            expect(actual_type).to eq("DELETE_ROWS")
+          end
+        end
+      end
+
+      context "MySQL 5.6 v2 ROW_EVENTS" do
+        context "EXT_WRITE_ROWS" do
+          let(:row_event_type) { EventType::EXT_WRITE_ROWS }
+          it "should return WRITE_ROWS" do
+            actual_type = nil
+            subject.callback = Proc.new do |row_event|
+              actual_type = row_event.type
+            end
+
+            subject.on_event(row_event)
+
+            expect(actual_type).to eq("WRITE_ROWS")
+          end
+        end
+
+        context "EXT_UPDATE_ROWS" do
+          let(:row_event_type) { EventType::EXT_UPDATE_ROWS }
+          it "should return UPDATE_ROWS" do
+            actual_type = nil
+            subject.callback = Proc.new do |row_event|
+              actual_type = row_event.type
+            end
+
+            subject.on_event(row_event)
+
+            expect(actual_type).to eq("UPDATE_ROWS")
+          end
+        end
+
+        context "EXT_DELETE_ROWS" do
+          let(:row_event_type) { EventType::EXT_DELETE_ROWS }
+          it "should return DELETE_ROWS" do
+            actual_type = nil
+            subject.callback = Proc.new do |row_event|
+              actual_type = row_event.type
+            end
+
+            subject.on_event(row_event)
+
+            expect(actual_type).to eq("DELETE_ROWS")
+          end
+        end
+      end
     end
   end
 end

--- a/vagrant/playbook.yml
+++ b/vagrant/playbook.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
-  sudo: yes
+  become: yes
   tasks:
 
   - name: Update package cache

--- a/vagrant/playbook.yml
+++ b/vagrant/playbook.yml
@@ -12,7 +12,7 @@
       - python-mysqldb
 
   - name: Install mysql server
-    apt: name=mysql-server state=present
+    apt: name=mysql-server-5.6 state=present
 
   - name: Copy mysql config file
     copy: src=files/ecco-my.cnf dest=/etc/mysql/conf.d/


### PR DESCRIPTION
- [x] Make Travis CI run
- [x] Green tests
  - Compare `#on_row_event, #on_save_position` specs between 5.5 and 5.6 (different order)
- [x] Ensure row events "type" return the same strings as before
- [x] Refactor
  - https://github.com/twingly/ecco/pull/20/files#r70984663
- [x] Update Vagrant machine to MySQL 5.6
- [x] Update README

https://docs.travis-ci.com/user/database-setup/#MySQL-5.6
