### PR TITLE
Use JRuby 9.2.7.0 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ language: ruby
 rvm:
   - jruby-9.0.5.0
   - jruby-9.1.17.0
-  - jruby-9.2.6.0
+  - jruby-9.2.7.0
 services:
   - mysql
 before_install:


### PR DESCRIPTION
53 issues fixed. Can't spot anything related to our usage, but updated here anyway.

https://www.jruby.org/2019/04/09/jruby-9-2-7-0.html