### PR TITLE
Drop offical support for MySQL 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/twingly/ecco.svg?branch=master)](https://travis-ci.org/twingly/ecco)
 
-MySQL (version 5.5 and 5.6) replication binlog parser using [mysql-binlog-connector-java].
+MySQL 5.6 replication binlog parser using [mysql-binlog-connector-java].
 
 ## Installation
 

--- a/spec/lib/ecco/row_event_listener_spec.rb
+++ b/spec/lib/ecco/row_event_listener_spec.rb
@@ -36,7 +36,7 @@ describe Ecco::RowEventListener do
     end
 
     describe "RowEvent#type" do
-      context "MySQL 5.5 v1 ROW_EVENTS" do
+      context "MySQL v1 ROW_EVENTS" do
         context "WRITE_ROWS" do
           let(:row_event_type) { EventType::WRITE_ROWS }
           it "should return WRITE_ROWS" do
@@ -80,7 +80,7 @@ describe Ecco::RowEventListener do
         end
       end
 
-      context "MySQL 5.6 v2 ROW_EVENTS" do
+      context "MySQL v2 ROW_EVENTS" do
         context "EXT_WRITE_ROWS" do
           let(:row_event_type) { EventType::EXT_WRITE_ROWS }
           it "should return WRITE_ROWS" do


### PR DESCRIPTION
MySQL 5.5 is EoL.

I choose to still support v1 row events as you may still run MySQL 5.6 and 5.7 using them (default was changed to v2 in MySQL 5.6). V1 is deprecated in MySQL 8.0 though. Resources:

* https://dev.mysql.com/doc/refman/5.6/en/replication-options-binary-log.html#sysvar_log_bin_use_v1_row_events
* https://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html#sysvar_log_bin_use_v1_row_events
* https://dev.mysql.com/doc/refman/8.0/en/replication-options-binary-log.html#sysvar_log_bin_use_v1_row_events

Close #45