### PR TITLE
Do not allow failures for MySQL 8.0 on Travis CI anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ env:
     - MYSQL_VERSION="5-7"
     - MYSQL_VERSION="8-0"
 
-jobs:
-  allow_failures:
-    - env: MYSQL_VERSION="8-0"
-
 script: bin/all_specs
 
 notifications:


### PR DESCRIPTION
As of #52 we have green tests for MySQL 8.0, so let's ensure we keep them green :)

Related to #41