### PR TITLE
Convert rows to ruby class

### DIFF
--- a/lib/ecco/row_event.rb
+++ b/lib/ecco/row_event.rb
@@ -1,3 +1,34 @@
 module Ecco
-  RowEvent = Struct.new(:type, :table_id, :database, :table, :rows)
+  class RowEvent
+    attr_accessor :type, :table_id, :database, :table, :rows
+
+    def initialize
+      @table_id = nil
+      @database = nil
+      @table = nil
+      @rows = nil
+      @type = nil
+    end
+  end
+
+  class RowEventWrite < RowEvent
+    def initialize
+      super
+      @type = "WRITE_ROWS"
+    end
+  end
+
+  class RowEventDelete < RowEvent
+    def initialize
+      super
+      @type = "DELETE_ROWS"
+    end
+  end
+
+  class RowEventUpdate < RowEvent
+    def initialize
+      super
+      @type = "UPDATE_ROWS"
+    end
+  end
 end

--- a/lib/ecco/ruby_rows.rb
+++ b/lib/ecco/ruby_rows.rb
@@ -1,0 +1,63 @@
+module Ecco
+  module RubyRows
+    ROW = 0
+
+    FIRST_COLUMN  = 0
+    SECOND_COLUMN = 1
+
+    KEY   = 0
+    VALUE = 1
+
+    def self.convert_to_ruby(java_row)
+      if java_row.inspect.include?("LinkedList")
+        java_linked_list_to_ruby_array(java_row)
+      else
+        java_array_list_to_ruby_array(java_row)
+      end
+    end
+
+    def self.java_linked_list_to_ruby_array(java_row)
+      ruby_row = Array.new(1) { Array.new(2) }
+
+      ruby_row[ROW][FIRST_COLUMN] = java_row[ROW][FIRST_COLUMN]
+      ruby_row[ROW][SECOND_COLUMN] = java_row[ROW][SECOND_COLUMN]
+
+      ruby_row
+    end
+
+    def self.java_array_list_to_ruby_array(java_row)
+      key_num = java_row[ROW].get_key[KEY]
+      key_val = java_row[ROW].get_key[VALUE]
+      val_num = java_row[ROW].get_value[KEY]
+      val_val = java_row[ROW].get_value[VALUE]
+
+      ruby_tuple = Tuple.new(key: [key_num, key_val], value: [val_num, val_val])
+      ruby_row = Array.new(1) { ruby_tuple }
+
+      ruby_row
+    end
+  end
+
+  class Tuple
+    KEY   = 0
+    VALUE = 1
+
+    attr_reader :tuple
+
+    def initialize(key:, value:)
+      @tuple = [key, value]
+    end
+
+    def key
+      @tuple[KEY]
+    end
+
+    def value
+      @tuple[VALUE]
+    end
+
+    def inspect
+      @tuple.to_s
+    end
+  end
+end

--- a/spec/event_context.rb
+++ b/spec/event_context.rb
@@ -2,7 +2,7 @@ java_import com.github.shyiko.mysql.binlog.event.EventType
 
 shared_context "event" do
   let(:table_id) { 1 }
-  let(:rows) { double("List") }
+  let(:rows) { Java::JavaUtil::LinkedList.new(Array.new(1) { Array.new(2) })}
   let(:database) { "some_database" }
   let(:table) { "some_table" }
   let(:table_event_type) { EventType::TABLE_MAP }


### PR DESCRIPTION
Putting this up here to get some feedback.

Related to: https://github.com/twingly/ecco/issues/26
The intent with this PR is to remove traces of Java objects in our rows.
Currently we have a (J)Ruby struct that holds both ruby objects and java objects.