### PR TITLE
Drop support for MySQL 5.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         include:
-        - { mysql: 5-6 }
         - { mysql: 5-7 }
         - { mysql: 8-0 }
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub Build Status](https://github.com/twingly/ecco/workflows/CI/badge.svg?branch=master)](https://github.com/twingly/ecco/actions)
 
-MySQL (5.6 and 5.7) replication binlog parser using [mysql-binlog-connector-java].
+MySQL (5.7 and 8.0) replication binlog parser using [mysql-binlog-connector-java].
 
 ## Installation
 
@@ -96,9 +96,6 @@ Ecco includes multiple Docker Compose definitions that can be used for this, one
 Start the desired version before running the tests:
 
 ```shell
-# MySQL 5.6
-docker-compose -f docker-compose-mysql-base.yml -f docker-compose-mysql-5-6.yml up
-
 # MySQL 5.7
 docker-compose -f docker-compose-mysql-base.yml -f docker-compose-mysql-5-7.yml up
 

--- a/docker-compose-mysql-5-6.yml
+++ b/docker-compose-mysql-5-6.yml
@@ -1,5 +1,0 @@
-version: "3.7"
-
-services:
-  db:
-    image: mysql:5.6


### PR DESCRIPTION
5.6's extended support period ends in "Feb 2021" [[1]]. We have internally moved on to later versions of MySQL. :wave:

[1]: http://www.oracle.com/us/support/library/lifetime-support-technology-069183.pdf