### PR TITLE
Upgrade Bundler to resolve CVE-2019-3881

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: jruby-9.2.17.0
-        bundler: 1
         bundler-cache: true
 
     - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,15 +8,17 @@ jobs:
   build:
     env:
       JRUBY_OPTS: '-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false'
-      JAVA_OPTS: '-Djava.security.properties=docker/ecco-java.security' # Enable TLS 1.1, required by MySQL 5.7
+      JAVA_OPTS: ${{ matrix.java_opts }}
 
     runs-on: ubuntu-18.04
 
     strategy:
       matrix:
         include:
-        - { mysql: 5-7 }
-        - { mysql: 8-0 }
+        - mysql: 5-7
+          java_opts: '-Djava.security.properties=docker/ecco-java.security' # Enable TLS 1.1, required by MySQL 5.7
+        - mysql: 8-0
+          java_opts: ''
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
   build:
     env:
       JRUBY_OPTS: '-J-XX:+TieredCompilation -J-XX:TieredStopAtLevel=1 -J-Xss2m -Xcompile.invokedynamic=false'
+      JAVA_OPTS: '-Djava.security.properties=docker/ecco-java.security' # Enable TLS 1.1, required by MySQL 5.7
 
     runs-on: ubuntu-18.04
 

--- a/docker-compose-mysql-5-7.yml
+++ b/docker-compose-mysql-5-7.yml
@@ -3,4 +3,3 @@ version: "3.7"
 services:
   db:
     image: mysql:5.7
-    command: --skip-ssl

--- a/docker-compose-mysql-5-7.yml
+++ b/docker-compose-mysql-5-7.yml
@@ -3,3 +3,4 @@ version: "3.7"
 services:
   db:
     image: mysql:5.7
+    command: --skip-ssl

--- a/docker/ecco-java.security
+++ b/docker/ecco-java.security
@@ -1,0 +1,3 @@
+jdk.tls.disabledAlgorithms=SSLv3, TLSv1, RC4, DES, MD5withRSA, \
+    DH keySize < 1024, EC keySize < 224, 3DES_EDE_CBC, anon, NULL, \
+    include jdk.disabled.namedCurves

--- a/ecco.gemspec
+++ b/ecco.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", ">= 2.1.0"
   spec.add_development_dependency "rake", "~> 12"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "sequel"

--- a/lib/ecco/client.rb
+++ b/lib/ecco/client.rb
@@ -3,6 +3,7 @@ require "ecco/row_event_listener"
 require "ecco/save_event_listener"
 require "ecco/lifecycle_failure_listener"
 require "ecco/error"
+require "forwardable"
 
 module Ecco
   class Client


### PR DESCRIPTION
Bundler 2 doesn't do `require "forwardable"`.